### PR TITLE
backend: handle article URL

### DIFF
--- a/backend/internal/biliapi/reply.go
+++ b/backend/internal/biliapi/reply.go
@@ -13,6 +13,7 @@ type ReplyType string
 
 const (
 	ReplyTypeVideo   = "1"
+	ReplyTypeArticle = "12"
 	ReplyTypeDynamic = "17"
 )
 

--- a/backend/route/lottery.go
+++ b/backend/route/lottery.go
@@ -49,6 +49,9 @@ func (*LotteryHandler) Lottery(ctx context.Context, form form.Lottery, errs bind
 	case strings.Contains(u.Path, "/opus/"):
 		replyType = biliapi.ReplyTypeDynamic
 		replyOid = strings.TrimPrefix(u.Path, "/opus/")
+	case strings.Contains(u.Path, "/read/"):
+		replyType = biliapi.ReplyTypeArticle
+		replyOid = strings.TrimPrefix(u.Path, "/read/cv")
 	case strings.Contains(u.Path, "/video/"):
 		bvid := strings.TrimPrefix(u.Path, "/video/")
 		bvid = strings.Trim(bvid, "/")


### PR DESCRIPTION
Now we can handle the replies in an article by adding a new reply type and parsing the URL which contains the `/read/` substring.

Test with this URL: `https://www.bilibili.com/read/cv22405580`